### PR TITLE
DOCS fix Sphinx cross-ref warnings and orphaned pages

### DIFF
--- a/docs/source/development.md
+++ b/docs/source/development.md
@@ -68,6 +68,7 @@ docker run -it --mount type=bind,src=/Users/Pavel/Documents/repos/SkiNet,dst=/wo
 If you do not need FUSE inside the container (recommended): mount blobfuse on the VM host and only bind the mounted directory into the container; then you can omit the SYS_ADMIN/device flags.
 
 
+(lightning-studio)=
 ## Lightning Studio
 
 ### Set up the environment on Studio

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,12 +14,15 @@ Welcome to SkiNet documentation!
    environment_docs
    development
    config
-   data_handling
+   data
+   datasets
    dataloaders
    azure_setup
    plotting
    training
    gpu_performance
+   debugging
+   sample_interface
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
## Summary

- Add explicit MyST label `(lightning-studio)=` to `development.md` so the `training.md` anchor link resolves without a `myst.xref_missing` warning
- Replace nonexistent `data_handling` toctree entry in `index.rst` with `data`; add `datasets`, `debugging`, and `sample_interface` which were orphaned (built but not in any toctree)
- All `{py:class}` / `{py:func}` cross-references in `training.md` (`LightningModel`, `find_best_threshold`, `setup_logging_and_callbacks`, `UNet2DModelConfig`, `TrainConfig`, etc.) now resolve to clickable API pages

## Test plan

- [ ] `make html` in `docs/` completes with **zero warnings**
- [ ] `docs/build/html/api/` contains `lightning_model.html`, `training_utils.html`, `logging_callbacks.html`, `experiment_keys.html`, `optuna_utils.html`
- [ ] Cross-reference links in the Training page navigate to the correct API entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)